### PR TITLE
Adiciona filtro de covid para os dados do TCE-PE

### DIFF
--- a/feed/scripts/create/create_contrato.sql
+++ b/feed/scripts/create/create_contrato.sql
@@ -12,7 +12,7 @@ CREATE TABLE IF NOT EXISTS "contrato" (
     "nm_orgao" VARCHAR(240),
     "nr_processo" VARCHAR(32),
     "ano_processo" INTEGER,
-    "tp_documento_contratado" VARCHAR(1),
+    "tp_documento_contratado" VARCHAR(10),
     "nr_documento_contratado" VARCHAR(14),
     "dt_inicio_vigencia" DATE,
     "dt_final_vigencia" DATE,

--- a/feed/scripts/create/create_item_contrato.sql
+++ b/feed/scripts/create/create_item_contrato.sql
@@ -22,7 +22,7 @@ CREATE TABLE IF NOT EXISTS "item_contrato" (
     "sigla_estado" VARCHAR(2),
     "id_estado" INTEGER,
     "dt_inicio_vigencia" DATE,
-    "ds_item" VARCHAR(3000),
+    "ds_item" TEXT,
     "sg_unidade_medida" VARCHAR(15),
     "categoria" INTEGER,
     "language" VARCHAR(15),

--- a/transformer/adapter/estados/PE/licitacoes/adaptador_licitacoes_pe.R
+++ b/transformer/adapter/estados/PE/licitacoes/adaptador_licitacoes_pe.R
@@ -35,15 +35,14 @@ adapta_info_licitacoes_pe <- function(licitacoes_df, tipo_filtro) {
     info_licitacoes <- licitacoes_df %>% 
       filter_licitacoes_merenda_pe()
     
+  } else if (tipo_filtro == "covid") {
+    info_licitacoes <- licitacoes_df %>%
+      filter_licitacoes_covid_pe()
+
+  } else {
+    stop("Tipo de filtro não definido. É possível filtrar pelos tipos 'merenda' ou 'covid")
   }
-  # else if (tipo_filtro == "covid") {
-  #   info_licitacoes <- licitacoes_df %>% 
-  #     filter_licitacoes_covid()
-  #   
-  # } else {
-  #   stop("Tipo de filtro não definido. É possível filtrar pelos tipos 'merenda' ou 'covid")
-  # }
-  
+
   
   info_licitacoes <- info_licitacoes %>% 
     janitor::clean_names() %>%

--- a/transformer/filters/filter_covid.R
+++ b/transformer/filters/filter_covid.R
@@ -1,12 +1,12 @@
 #' Carrega licitações marcadas pelo TCE-RS como sendo do período da Pandemia do Covid-19
 #'
-#' @param anos Vector de inteiros com anos para captura das licitações
+#' @param licitacoes_df Dataframe de licitações
 #'
 #' @return Dataframe com informações das licitações relacionadas ao COVID-19. 
 #' Adiciona uma coluna com o assunto covid
 #'   
 #' @examples 
-#' licitacoes <- filter_licitacoes_covid(2019)
+#' licitacoes <- filter_licitacoes_covid(import_licitacoes(2020))
 #' 
 filter_licitacoes_covid <- function(licitacoes_df) {
   
@@ -14,5 +14,34 @@ filter_licitacoes_covid <- function(licitacoes_df) {
     dplyr::filter(BL_COVID19 == "S") %>% 
     dplyr::mutate(assunto = "covid")
   
+  return(licitacoes_filtradas)
+}
+
+
+#' Carrega licitações do TCE-PE relacionadas a Pandemia do COVID-19
+#'
+#' @param anos Vector de inteiros com anos para captura das licitações
+#'
+#' @return Dataframe com informações das licitações relacionadas ao COVID-19. 
+#' Adiciona uma coluna com o assunto covid
+#'   
+#' @examples 
+#' licitacoes <- filter_licitacoes_covid_pe(import_licitacoes_pe(2020))
+#' 
+filter_licitacoes_covid_pe <- function(licitacoes_df) {
+  
+  licitacoes_filtradas <- licitacoes_df %>% 
+    dplyr::mutate(DS_OBJETO_PROCESSED = iconv(ObjetoConformeEdital, 
+                                              from="UTF-8", 
+                                              to="ASCII//TRANSLIT")) %>% 
+    dplyr::mutate(
+      isCompraEmergencial = grepl(
+        "^.*(corona|covid|pandemia|sars-cov-2|linha de frente|testes rapidos|alcool gel).*$",
+        tolower(DS_OBJETO_PROCESSED)
+      )
+    ) %>%
+    dplyr::filter(isCompraEmergencial) %>%
+    dplyr::mutate(assunto = "covid")
+
   return(licitacoes_filtradas)
 }

--- a/transformer/processor/estados/PE/orgaos/processador_orgaos_pe.R
+++ b/transformer/processor/estados/PE/orgaos/processador_orgaos_pe.R
@@ -1,4 +1,5 @@
 source(here::here("transformer/adapter/estados/PE/orgaos/adaptador_orgaos_pe.R"))
+source(here::here("transformer/adapter/estados/PE/licitacoes/adaptador_licitacoes_pe.R"))
 
 #' Processa dados dos órgãos do estado de Pernambuco
 #' 
@@ -7,9 +8,16 @@ source(here::here("transformer/adapter/estados/PE/orgaos/adaptador_orgaos_pe.R")
 #' @examples 
 #' info_orgaos_pe <- processa_orgaos_pe()
 processa_orgaos_pe <- function() {
+  licitacoes_pe_orgaos <- import_licitacoes_pe() %>%
+    adapta_info_licitacoes_pe(tipo_filtro = filtro) %>%
+    add_info_estado(sigla_estado = "PE", id_estado = "26") %>% 
+    dplyr::distinct(cd_orgao, nm_orgao, sigla_estado, id_estado)
+
   info_orgaos_pe <- import_orgaos_municipais_pe() %>%
     adapta_info_orgaos_pe(import_orgaos_estaduais_pe(), import_municipios_pe()) %>%
-    add_info_estado(sigla_estado = "PE", id_estado = "26")
+    add_info_estado(sigla_estado = "PE", id_estado = "26") %>% 
+    dplyr::bind_rows(licitacoes_pe_orgaos) %>% 
+    dplyr::distinct(cd_orgao, .keep_all = TRUE)
   
   return(info_orgaos_pe)
 }

--- a/transformer/processor/export_dados_bd.R
+++ b/transformer/processor/export_dados_bd.R
@@ -246,11 +246,15 @@ info_item_contrato <- itens_contratos_rs %>%
          nr_licitacao, ano_licitacao, cd_tipo_modalidade, nr_contrato, ano_contrato, tp_instrumento_contrato, 
          nr_item, qt_itens_contrato, vl_item_contrato, vl_total_item_contrato, origem_valor, sigla_estado, id_estado, dt_inicio_vigencia, ds_item, 
          sg_unidade_medida, categoria, language, ds_1, ds_2, ds_3, servico)
-
++
 info_fornecedores_contratos <- bind_rows(fornecedores_contratos_rs,
                                          fornecedores_contratos_pe) %>%
   join_contratos_e_fornecedores(info_contratos %>%
                                   dplyr::select(nr_documento_contratado)) %>%
+  dplyr::distinct(nr_documento, id_estado, .keep_all = TRUE) %>% 
+  dplyr::group_by(nr_documento) %>% 
+  dplyr::mutate(total_de_contratos = sum(total_de_contratos, na.rm = T),
+                data_primeiro_contrato = min(data_primeiro_contrato, na.rm = T)) %>% 
   dplyr::distinct(nr_documento, .keep_all = TRUE) %>%
   dplyr::select(nr_documento, id_estado, nm_pessoa, tp_pessoa, total_de_contratos, data_primeiro_contrato)
 

--- a/transformer/processor/export_dados_bd.R
+++ b/transformer/processor/export_dados_bd.R
@@ -200,14 +200,14 @@ info_documento_licitacao <- documento_licitacao_rs %>%
 
 info_compras <- compras_rs %>%
   dplyr::left_join(info_licitacoes %>%
-                     dplyr::select(cd_orgao, nr_licitacao, ano_licitacao, cd_tipo_modalidade,
+                     dplyr::select(cd_orgao, nr_licitacao, ano_licitacao, cd_tipo_modalidade, id_estado,
                                    id_licitacao, id_orgao, nm_orgao),
-                   by = c("cd_orgao", "nr_licitacao", "ano_licitacao", "cd_tipo_modalidade")) %>%
+                   by = c("cd_orgao", "nr_licitacao", "ano_licitacao", "cd_tipo_modalidade", "id_estado")) %>%
   dplyr::filter(!is.na(id_licitacao)) %>%
   generate_hash_id(c("id_orgao", "ano_licitacao", "nr_licitacao", "cd_tipo_modalidade",
                      "nr_contrato", "ano_contrato", "tp_instrumento_contrato"), CONTRATO_ID) %>%
   dplyr::distinct(id_licitacao, id_contrato, .keep_all = TRUE) %>%
-  dplyr::select(id_contrato, id_licitacao, cd_orgao, nr_contrato, ano_contrato, nm_orgao,
+  dplyr::select(id_contrato, id_licitacao, id_orgao, cd_orgao, nr_contrato, ano_contrato, nm_orgao,
                 nr_licitacao, ano_licitacao, cd_tipo_modalidade,
                 dt_inicio_vigencia, vl_contrato,
                 descricao_objeto_contrato = ds_objeto,

--- a/transformer/processor/export_dados_bd.R
+++ b/transformer/processor/export_dados_bd.R
@@ -1,6 +1,7 @@
 library(tidyverse)
 library(here)
 library(magrittr)
+library(futile.logger)
 
 help <- "
 Usage:
@@ -50,92 +51,92 @@ source(here::here("transformer/processor/estados/PE/contratos/processador_itens_
 ## na raiz desse repositório)
 
 # Processamento dos dados
-message("#### Iniciando processamento...")
+flog.info("#### Iniciando processamento...")
 
 #--------------------------------- Processamento das tabelas do Rio Grande do Sul-------------------------------------------
-message("#### Processando infos. do RS...")
+flog.info("#### Processando infos. do RS...")
 
 ## Licitações
-message("#### licitações...")
+flog.info("#### licitações...")
 licitacoes_rs <- processa_licitacoes_rs(anos, filtro)
 
 ## Órgãos --------------------------------------------------------------------------
-message("#### órgãos")
+flog.info("#### órgãos")
 info_orgaos_rs <- processa_orgaos_rs(anos, filtro)
 
 ## Licitantes ----------------------------------------------------------------------
-message("### licitantes...")
+flog.info("### licitantes...")
 licitantes_rs <- processa_licitantes_rs(anos)
 
 ## Itens de licitações -------------------------------------------------------------
-message("#### itens de licitações...")
+flog.info("#### itens de licitações...")
 itens_licitacao_rs <- processa_itens_licitacoes_rs(anos)
 
 ## Documentos de licitações --------------------------------------------------------
-message("#### Documentos de licitações...")
+flog.info("#### Documentos de licitações...")
 tipos_documento_licitacao_rs <- processa_tipos_documentos_licitacoes_rs()
 documento_licitacao_rs <- processa_documentos_licitacoes_rs(anos)
 
 ## Contratos ------------------------------------------------------------------------
-message("#### contratos...")
+flog.info("#### contratos...")
 contratos_rs <- processa_contratos_rs(anos)
 
 ## *Compras* ----------------------------------------------------------------------------
-message("#### licitações encerradas...")
+flog.info("#### licitações encerradas...")
 licitacoes_encerradas_rs <- processa_eventos_licitacoes_rs(anos)
 
-message("#### lotes de licitação...")
+flog.info("#### lotes de licitação...")
 lotes_licitacoes_rs <- processa_lotes_licitacoes_rs(anos)
 
 ### Itens de contratos e licitação -------------------------------------------------------
-message("#### preparando dados de itens de licitação e contratos...")
+flog.info("#### preparando dados de itens de licitação e contratos...")
 itens_contrato <- processa_itens_contrato_rs(anos)
 itens_licitacao <- processa_itens_licitacoes_renamed_columns_rs()
 
-message("#### processando compras...")
+flog.info("#### processando compras...")
 compras_rs <- processa_compras_rs(anos, licitacoes_encerradas_rs, lotes_licitacoes_rs, itens_licitacao, itens_contrato)
 
-message("#### itens com contratos...")
+flog.info("#### itens com contratos...")
 itens_contrato <- processa_itens_contratos_renamed_columns_rs(itens_contrato)
 
-message("#### itens sem contratos...")
+flog.info("#### itens sem contratos...")
 itens_comprados <- processa_item_licitacao_comprados_rs(anos, compras_rs, itens_contrato)
 
-message("#### processando todos os itens comprados...")
+flog.info("#### processando todos os itens comprados...")
 itens_contratos_rs <- processa_todos_itens_comprados(itens_comprados, itens_licitacao_rs %>%
                                                        select("ds_item", "sg_unidade_medida", "cd_orgao", 
                                                               "ano_licitacao", "nr_licitacao", "cd_tipo_modalidade", 
                                                               "nr_lote", "nr_item"))
 
 ## Fornecedores nos contratos --------------------------------------------------------------
-message("#### fornecedores (contratos)...")
+flog.info("#### fornecedores (contratos)...")
 fornecedores_contratos_rs <- processa_fornecedores_contrato_rs(anos, contratos_rs, compras_rs)
 
 ## Alterações contratos --------------------------------------------------------------------
-message("#### alterações de contratos...")
+flog.info("#### alterações de contratos...")
 alteracoes_rs <- processa_alteracoes_contratos_rs(anos)
 tipo_operacao_alteracao <- processa_tipos_alteracoes_contratos_rs(anos)
 
 #--------------------------------- Processamento das tabelas de Pernambuco-------------------
-message("#### Processando infos. de PE...")
+flog.info("#### Processando infos. de PE...")
 # Órgãos ------------------------------------------------------------------------------------
-message("#### órgãos...")
+flog.info("#### órgãos...")
 info_orgaos_pe <- processa_orgaos_pe()
 
 # Licitacoes  -------------------------------------------------------------------------------
-message("#### Licitações...")
+flog.info("#### Licitações...")
 licitacoes_pe <- processa_licitacoes_pe(filtro)
 
 # Contratos  --------------------------------------------------------------------------------
-message("#### Contratos...")
+flog.info("#### Contratos...")
 contratos_pe <- processa_contratos_pe()
 
 # Fornecedores contratos  -------------------------------------------------------------------
-message("#### Fornecedores contratos...")
+flog.info("#### Fornecedores contratos...")
 fornecedores_contratos_pe <- processa_fornecedores_contratos_pe(contratos_pe)
 
 # Itens dos contratos  -------------------------------------------------------------------
-message("#### Itens contratos...")
+flog.info("#### Itens contratos...")
 itens_contratos_pe <- processa_itens_contrato_pe(contratos_pe, licitacoes_pe)
 
 #---------------------------------------------- Agregador------------------------------------------------------------
@@ -263,7 +264,7 @@ info_alteracoes_contrato <- alteracoes_rs %>%
 
 
 #----------------------------------------------- # Escrita dos dados-------------------------------------------------
-message("#### escrevendo dados...")
+flog.info("#### escrevendo dados...")
 
 readr::write_csv(info_licitacoes, here("data/bd/info_licitacao.csv"))
 readr::write_csv(info_licitantes, here("data/bd/info_licitante.csv"))
@@ -275,5 +276,5 @@ readr::write_csv(info_item_contrato, here("data/bd/info_item_contrato.csv"))
 readr::write_csv(info_alteracoes_contrato, here("data/bd/info_alteracao_contrato.csv"))
 readr::write_csv(info_orgaos, here("data/bd/info_orgaos.csv"))
 
-message("#### Processamento concluído!")
-message("#### Confira o diretório data/bd")
+flog.info("#### Processamento concluído!")
+flog.info("#### Confira o diretório data/bd")

--- a/transformer/processor/export_fornecedores_bd.R
+++ b/transformer/processor/export_fornecedores_bd.R
@@ -47,7 +47,11 @@ info_fornecedores_contratos <- bind_rows(fornecedores_contratos_rs,
                                          fornecedores_contratos_pe) %>% 
   join_contratos_e_fornecedores(contratos_processados_df %>% 
                                   dplyr::select(nr_documento_contratado)) %>% 
-  dplyr::distinct(nr_documento, .keep_all = TRUE) %>% 
+  dplyr::distinct(nr_documento, id_estado, .keep_all = TRUE) %>% 
+  dplyr::group_by(nr_documento) %>% 
+  dplyr::mutate(total_de_contratos = sum(total_de_contratos, na.rm = T),
+                data_primeiro_contrato = min(data_primeiro_contrato, na.rm = T)) %>% 
+  dplyr::distinct(nr_documento, .keep_all = TRUE) %>%
   dplyr::select(nr_documento, id_estado, nm_pessoa, tp_pessoa, total_de_contratos, data_primeiro_contrato)
 
 readr::write_csv(info_fornecedores_contratos, here::here("data/bd/info_fornecedores_contrato.csv"))

--- a/transformer/processor/export_fornecedores_bd.R
+++ b/transformer/processor/export_fornecedores_bd.R
@@ -1,5 +1,6 @@
 library(tidyverse)
 library(magrittr)
+library(futile.logger)
 
 help <- "
 Usage:
@@ -14,27 +15,41 @@ if (length(args) < min_num_args) {
 }
 
 anos <- unlist(strsplit(args[1], split=","))
-# anos = c(2018, 2019, 2020)
+# anos = c(2018, 2019, 2020, 2021)
 
 source(here::here("transformer/adapter/estados/RS/contratos/adaptador_contratos_rs.R"))
 source(here::here("transformer/adapter/estados/RS/contratos/adaptador_fornecedores_contratos_rs.R"))
+source(here::here("transformer/processor/estados/PE/contratos/processador_contratos_pe.R"))
+source(here::here("transformer/processor/estados/PE/contratos/processador_fornecedores_contratos_pe.R"))
+source(here::here("transformer/utils/utils.R"))
 source(here::here("transformer/utils/read_utils.R"))
 source(here::here("transformer/utils/join_utils.R"))
 
-compras_df <- read_contratos_processados()
+flog.info("#### Atualizando dados de fornecedores do RS...")
+contratos_processados_df <- read_contratos_processados()
 
-print("Atualizando dados de fornecedores...")
-contratos <- import_contratos(anos) %>% 
+compras_rs <- contratos_processados_df %>% 
+  filter(sigla_estado == "RS")
+contratos_rs <- import_contratos(anos) %>%
   adapta_info_contratos()
 
-info_fornecedores_contratos <- import_fornecedores(anos) %>% 
-  adapta_info_fornecedores(contratos, compras_df) %>% 
-  join_contratos_e_fornecedores(compras_df %>% 
+fornecedores_contratos_rs <- import_fornecedores(anos) %>% 
+  adapta_info_fornecedores(contratos_rs, compras_rs) %>% 
+  add_info_estado(sigla = "RS", id_estado = "43")
+
+flog.info("#### Atualizando dados de fornecedores do PE...")
+contratos_pe <- processa_contratos_pe()
+
+fornecedores_contratos_pe <- processa_fornecedores_contratos_pe(contratos_pe)
+
+flog.info("#### Agregando dados de fornecedores")
+info_fornecedores_contratos <- bind_rows(fornecedores_contratos_rs,
+                                         fornecedores_contratos_pe) %>% 
+  join_contratos_e_fornecedores(contratos_processados_df %>% 
                                   dplyr::select(nr_documento_contratado)) %>% 
   dplyr::distinct(nr_documento, .keep_all = TRUE) %>% 
-  dplyr::select(nr_documento, nm_pessoa, tp_pessoa, total_de_contratos, data_primeiro_contrato)
-
+  dplyr::select(nr_documento, id_estado, nm_pessoa, tp_pessoa, total_de_contratos, data_primeiro_contrato)
 
 readr::write_csv(info_fornecedores_contratos, here::here("data/bd/info_fornecedores_contrato.csv"))
 
-print("Concluído!")
+flog.info("Concluído!")


### PR DESCRIPTION
## Mudanças
- Adiciona filtro de covid para os dados do TCE-PE
- Refatora módulo de atualização dos dados de fornecedores
- Altera feed para nova definição das colunas
- Lida com casos de fornecedores que atuaram em mais de um estado

## Flags
- Depende da revisão e aprovação do PR https://github.com/analytics-ufcg/ta-de-pe-dados/pull/131