### PR TITLE
Adiciona nova versão do alerta de inidôneos

### DIFF
--- a/transformer/processor/geral/alertas/export_alertas_bd.R
+++ b/transformer/processor/geral/alertas/export_alertas_bd.R
@@ -36,7 +36,7 @@ tipos_alerta <- create_tipo_alertas()
 
 alertas_data <- processa_alertas_data_abertura_contrato(anos)
 alertas_cnae_atipico_item <- processa_alertas_cnaes_atipicos_itens(filtro)
-alertas_empresas_inidoneas <- processa_alerta_inidoneas()
+alertas_empresas_inidoneas <- processa_alerta_inidoneas(anos)
 
 alertas <- bind_rows(alertas_data, 
                      alertas_cnae_atipico_item, 

--- a/transformer/processor/geral/alertas/processa_alerta_inidoneas.R
+++ b/transformer/processor/geral/alertas/processa_alerta_inidoneas.R
@@ -13,12 +13,12 @@ processa_alerta_inidoneas <- function(anos) {
   flog.info("Processando alertas de empresas inidôneas...")
   
   ceis <- read_csv(here::here("data/inidoneos/ceis.csv"), col_types = cols(.default = col_character())) %>% 
-    mutate(fonte = "CEIS")
+    mutate(fonte = "Cadastro Nacional de Empresas Inidôneas e Suspensas (CEIS)")
   
   cnep <- read_csv(here::here("data/inidoneos/cnep.csv"), 
                    col_types = cols(.default = col_character(),
                                     `VALOR DA MULTA` = col_double())) %>% 
-    mutate(fonte = "CNEP")
+    mutate(fonte = "Cadastro Nacional das Empresas Punidas (CNEP)")
   
   cadastros <- ceis %>% 
     bind_rows(cnep)
@@ -45,8 +45,8 @@ processa_alerta_inidoneas <- function(anos) {
     ungroup() %>% 
     filter((data_inicio <= dt_inicio_vigencia) & (dt_inicio_vigencia <= data_fim)) %>% 
     mutate(id_tipo = 3,
-           info = str_glue("O fornecedor estava presente no {fonte} com uma sanção vigente durante o início do contrato. ", 
-                           "A sanção tem o período de vigência de {format(data_inicio, '%d/%m/%Y')} a {format(data_fim, '%d/%m/%Y')}.")) %>% 
+           info = str_glue("Fornecedor com sanção vigente no {fonte} no momento da contratação. ", 
+                           "Vigência da sanção: {format(data_inicio, '%d/%m/%Y')} a {format(data_fim, '%d/%m/%Y')}.")) %>% 
     arrange(nr_documento, desc(data_inicio)) %>% 
     distinct(nr_documento, id_contrato, .keep_all = TRUE) %>% 
     select(nr_documento, id_contrato, id_tipo, info)

--- a/transformer/processor/geral/alertas/processa_alerta_inidoneas.R
+++ b/transformer/processor/geral/alertas/processa_alerta_inidoneas.R
@@ -2,13 +2,15 @@ library(tidyverse)
 library(futile.logger)
 
 source(here::here("transformer/utils/read_utils.R"))
-
+source(here::here("transformer/processor/geral/alertas/processa_alertas_data.R"))
 
 #' @title Gera alertas para empresas inidoneas
 #' @description Gera alertas para empresas inidoneas que estão presentes na lista de fornecedores
+#' @param Anos para consideração dos contratos feitos com fornecedores sancionados. 
+#' Array com os anos para recuperação dos contratos. Exemplo: c(2018, 2019, 2020)
 #' @return Dataframe com os alertas gerados
-processa_alerta_inidoneas <- function() {
-  flog.info("Processando alertas de itens atípicos por atividade econômica...")
+processa_alerta_inidoneas <- function(anos) {
+  flog.info("Processando alertas de empresas inidôneas...")
   
   ceis <- read_csv(here::here("data/inidoneos/ceis.csv"), col_types = cols(.default = col_character())) %>% 
     mutate(fonte = "CEIS")
@@ -23,23 +25,30 @@ processa_alerta_inidoneas <- function() {
   
   fornecedores <- read_fornecedores_processados()
   
+  contratos_merge <- processa_contratos_info(anos) %>% 
+    distinct(id_contrato, nr_contrato, nr_documento_contratado, dt_inicio_vigencia)
+  
   fornecedores_inidoneos <- fornecedores %>% 
     inner_join(cadastros %>% 
                 select(cnpj = `CPF OU CNPJ DO SANCIONADO`,
                        data_inicio = `DATA INÍCIO SANÇÃO`,
                        data_fim = `DATA FINAL SANÇÃO`,
                        num_processo = `NÚMERO DO PROCESSO`,
-                       fonte),
+                       fonte) %>% 
+                 mutate(data_inicio = as.POSIXct(data_inicio, format="%d/%m/%Y"),
+                        data_fim = as.POSIXct(data_fim, format="%d/%m/%Y")),
                by = c("nr_documento" = "cnpj")) %>% 
+    inner_join(contratos_merge, 
+               by = c("nr_documento" = "nr_documento_contratado")) %>% 
     group_by(nr_documento) %>% 
     mutate(n_sancoes = n_distinct(num_processo)) %>% 
     ungroup() %>% 
+    filter((data_inicio <= dt_inicio_vigencia) & (dt_inicio_vigencia <= data_fim)) %>% 
     mutate(id_tipo = 3,
-           id_contrato = NA_character_,
-           info = str_glue("Este fornecedor foi encontrado no cadastro do {fonte} (nº de sanções: {n_sancoes}). ", 
-                           "A última sanção tem o período de vigência entre {data_inicio} e {data_fim}.")) %>% 
+           info = str_glue("O fornecedor estava presente no {fonte} com uma sanção vigente durante o início do contrato. ", 
+                           "A sanção tem o período de vigência de {format(data_inicio, '%d/%m/%Y')} a {format(data_fim, '%d/%m/%Y')}.")) %>% 
     arrange(nr_documento, desc(data_inicio)) %>% 
-    distinct(nr_documento, .keep_all = TRUE) %>% 
+    distinct(nr_documento, id_contrato, .keep_all = TRUE) %>% 
     select(nr_documento, id_contrato, id_tipo, info)
   
   flog.info(str_glue("{fornecedores_inidoneos %>% nrow()} alertas de fornecedores inidôneos foram capturados"))

--- a/transformer/processor/geral/alertas/processa_alertas_data.R
+++ b/transformer/processor/geral/alertas/processa_alertas_data.R
@@ -17,7 +17,7 @@ source(here::here("transformer/processor/aggregator/agrega_contratos.R"))
 #' alertas <- create_tipo_alertas()
 create_tipo_alertas <- function() {
   id_tipo <- c(1, 2, 3)
-  titulo <- c("Contratado logo após a abertura", "Produtos atípicos", "Inidôneos")
+  titulo <- c("Contratado logo após a abertura", "Produtos atípicos", "Contratado inidôneo")
   
   tipos_alertas <- data.frame(id_tipo, titulo)
   flog.info(str_glue("{tipos_alertas %>% nrow()} tipos de alertas gerados"))

--- a/transformer/processor/geral/alertas/processa_alertas_data.R
+++ b/transformer/processor/geral/alertas/processa_alertas_data.R
@@ -113,7 +113,7 @@ processa_alertas_data_abertura_contrato <- function(anos) {
   
   flog.info(str_glue("{fornecedores %>% nrow()} fornecedores com o alerta!"))
   
-  contratos_merge <- .processa_contratos_info(anos)
+  contratos_merge <- processa_contratos_info(anos)
   flog.info(str_glue("Pesquisa feita em {contratos_merge %>% nrow()} contratos de {contratos_merge %>% count(id_estado) %>% nrow()} estados."))
   
   fornecedores_contratos <- fornecedores %>% 
@@ -138,8 +138,8 @@ processa_alertas_data_abertura_contrato <- function(anos) {
 #' @return Dataframe com alertas para a diferença de daras
 #' 
 #' @examples 
-#' contratos_merge <- .processa_contratos_info(c(2018, 2019, 2020))
-.processa_contratos_info <- function(anos) {
+#' contratos_merge <- processa_contratos_info(c(2018, 2019, 2020))
+processa_contratos_info <- function(anos) {
   contratos_processados <- read_contratos_processados() %>% 
     mutate(id_orgao = as.character(id_orgao)) %>% 
     select(id_contrato, id_estado, id_orgao, cd_orgao, nr_licitacao, ano_licitacao, cd_tipo_modalidade, 


### PR DESCRIPTION
## Mudanças
- Adiciona nova versão do alerta de inidôneos. Cruza com dados de contratos para gerar um alerta por contrato.
- Adiciona filtro para considerar apenas o alerta quando o fornecedor for contrato enquanto estiver sancionado no CEIS/CNEP
