### PR TITLE
Configura rollbar para monitoramento de erros do projeto

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -23,3 +23,6 @@ PATH_DADOS=./data
 PATH_VOLUME_DADOS=./data
 PATH_VOLUME_DADOS_BD=./data/postgres_data
 LOG_FOLDERPATH=./logs/
+
+ROLLBAR_ACCESS_TOKEN=
+R_ENV=development

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,5 +31,6 @@ RUN R -e "install.packages(c('here', 'janitor', 'purrr', 'optparse', 'odbc', 'DB
 RUN R -e "install.packages('RPostgres', repos='http://cran.rstudio.com/')"
 RUN Rscript -e 'devtools::install_version("tidyselect", version = "1.1.0", repos = "http://cran.rstudio.com/")'
 RUN Rscript -e "install.packages('futile.logger', repos='http://cran.rstudio.com/')"
+RUN Rscript -e "install.packages('rollbar', repos='http://cran.rstudio.com/')"
 
 EXPOSE 8787

--- a/README.md
+++ b/README.md
@@ -60,6 +60,24 @@ b) Preencha as variáveis contidas no .env.sample também para o `.env`. Altere 
 
 c) Do **diretório raiz desse repositório** execute o comando a seguir que irá levantar os serviços:
 
+Você pode opcionalmente realizar o build das imagens:
+
+```shell
+docker-compose build
+```
+
+Caso o seguite erro apareça:
+```
+error checking context: 'can't stat '<path>/ta-de-pe-dados/data/postgres_data''.
+ERROR: Service 'rbase' failed to build : Build failed
+```
+
+execute o seguinte comando para alterar a permissão de acesso ao diretório do postgres_data:
+
+```
+sudo chown -R <seu-user>:<seu-user> data/
+```
+
 ```shell
 docker-compose up -d
 ```

--- a/transformer/processor/estados/RS/empenhos/export_empenhos_bd.R
+++ b/transformer/processor/estados/RS/empenhos/export_empenhos_bd.R
@@ -2,6 +2,8 @@ library(tidyverse)
 library(here)
 library(magrittr)
 
+source(here::here("transformer/utils/rollbar.R"))
+
 help <- "
 Usage:
 Rscript export_empenhos_bd.R

--- a/transformer/processor/export_dados_bd.R
+++ b/transformer/processor/export_dados_bd.R
@@ -3,6 +3,8 @@ library(here)
 library(magrittr)
 library(futile.logger)
 
+source(here::here("transformer/utils/rollbar.R"))
+
 help <- "
 Usage:
 Rscript export_dados_bd.R <anos> <filtro>

--- a/transformer/processor/export_fornecedores_bd.R
+++ b/transformer/processor/export_fornecedores_bd.R
@@ -2,6 +2,8 @@ library(tidyverse)
 library(magrittr)
 library(futile.logger)
 
+source(here::here("transformer/utils/rollbar.R"))
+
 help <- "
 Usage:
 Rscript export_fornecedores_bd.R <anos>

--- a/transformer/processor/geral/alertas/export_alertas_bd.R
+++ b/transformer/processor/geral/alertas/export_alertas_bd.R
@@ -2,6 +2,8 @@ library(tidyverse)
 library(magrittr)
 library(futile.logger)
 
+source(here::here("transformer/utils/rollbar.R"))
+
 help <- "
 Usage:
 Rscript export_alertas_bd.R <anos> <filtro>

--- a/transformer/processor/geral/alertas/export_itens_similares.R
+++ b/transformer/processor/geral/alertas/export_itens_similares.R
@@ -3,6 +3,8 @@ library(magrittr)
 source(here::here("transformer/utils/bd_constants.R"))
 source(here::here("transformer/utils/utils.R"))
 source(here::here("transformer/utils/constants.R"))
+source(here::here("transformer/utils/rollbar.R"))
+
 .HELP <- "Rscript fetch_dados_ta_na_mesa.R"
 
 ta_na_mesa_db <- NULL

--- a/transformer/processor/geral/novidades/export_novidades_bd.R
+++ b/transformer/processor/geral/novidades/export_novidades_bd.R
@@ -2,6 +2,8 @@ library(tidyverse)
 library(magrittr)
 library(futile.logger)
 
+source(here::here("transformer/utils/rollbar.R"))
+
 help <- "
 Usage:
 Rscript export_novidades_bd.R

--- a/transformer/utils/rollbar.R
+++ b/transformer/utils/rollbar.R
@@ -1,0 +1,15 @@
+library(rollbar)
+library(here)
+
+readRenviron(here(".Renviron"))
+
+R_ENV <- Sys.getenv("R_ENV")
+
+if (R_ENV == "production") {
+  rollbar.configure(
+    access_token = Sys.getenv("ROLLBAR_ACCESS_TOKEN"),
+    env = Sys.getenv("R_ENV"),
+    root = here("")
+  )
+  rollbar.attach()
+}


### PR DESCRIPTION
## Mudanças
- Configura rollbar para monitoramento de erros do projeto

## Flags
- Para configurar o acesso ao rollbar é preciso configurar as variáveis de ambiente corretamente. Acesse o drive do projeto para recuperá-las (Tá na mesa/Documentação/ Credenciais - environment
- Para acessar o rollbar você deve entrar no time do ta-de-pe-dados. Caso o convite não tenha chegado, entre em contato.
- Para testar você deve mudar no seu .env o valor da variável R_ENV para production e em seguida executar: `make process-data`. Você verá que o rollbar exibirá o erro do número errado de argumentos. Lembre-se de voltar ao valor development para a variável R_ENV após o teste.