### PR TITLE
Adiciona regra pra remover unidade no inicio da descrição

### DIFF
--- a/transformer/adapter/estados/Federal/contratos/adaptador_itens_compra_federal.R
+++ b/transformer/adapter/estados/Federal/contratos/adaptador_itens_compra_federal.R
@@ -77,7 +77,7 @@ adapta_info_itens_compras_federal <- function(itens_compra_federal_df, empenhos_
     dplyr::mutate(item = str_remove_all(item, "^'([[:alpha:]]*(.)*?)*'[[:blank:]]*")) %>%
     dplyr::mutate(ds_tidy = str_remove_all(descricao, "^( )*([$]|-|_|,|@|[.]|'|#|])*( )?")) %>%
     dplyr::mutate(ds_tidy = str_replace_all(ds_tidy, '((\r|\n|\t)|( ){2,})+', ' ')) %>% 
-    dplyr::mutate(ds_tidy = str_replace_all(ds_tidy, '^[0-9]*,[0-9]* ((?i)unidade|garrafa|frasco|litro)', ' ')) %>% 
+    dplyr::mutate(ds_tidy = str_remove_all(ds_tidy, '^[0-9]*,[0-9]* (?i)((unidade)(s\b|\b)|(garrafa)(s\b|\b)|(frasco)(s\b|\b)|(litro)(s\b|\b))')) %>% 
     dplyr::mutate(ds_item = case_when(
       !is.na(item) ~ if_else(tolower(item) == tolower(descricao_restante), 
                              str_glue("{item} {marca}"), 

--- a/transformer/adapter/estados/Federal/contratos/adaptador_itens_compra_federal.R
+++ b/transformer/adapter/estados/Federal/contratos/adaptador_itens_compra_federal.R
@@ -75,9 +75,9 @@ adapta_info_itens_compras_federal <- function(itens_compra_federal_df, empenhos_
       vl_total_item_contrato = as.double(vl_total_item_contrato)
     ) %>%
     dplyr::mutate(item = str_remove_all(item, "^'([[:alpha:]]*(.)*?)*'[[:blank:]]*")) %>%
-    dplyr::mutate(ds_tidy = str_remove_all(descricao, "^( )*([$]|-|_|,|@|[.]|'|#|])*( )?")) %>%
+    dplyr::mutate(ds_tidy = str_remove_all(descricao, '^[0-9]+,[0-9]+ [A-Za-záàâãéèêíïóôõöúçñÁÀÂÃÉÈÍÏÓÔÕÖÚÇÑ\'\.]* +([0-9]+,[0-9]+ [A-Za-záàâãéèêíïóôõöúçñÁÀÂÃÉÈÍÏÓÔÕÖÚÇÑ\'\.]* +)?')) %>% 
+    dplyr::mutate(ds_tidy = str_remove_all(ds_tidy, "^( )*([$]|-|_|,|@|[.]|'|#|])*( )?")) %>%
     dplyr::mutate(ds_tidy = str_replace_all(ds_tidy, '((\r|\n|\t)|( ){2,})+', ' ')) %>% 
-    dplyr::mutate(ds_tidy = str_remove_all(ds_tidy, '^[0-9]*,[0-9]* (?i)((unidade)(s\b|\b)|(garrafa)(s\b|\b)|(frasco)(s\b|\b)|(litro)(s\b|\b))')) %>% 
     dplyr::mutate(ds_item = case_when(
       !is.na(item) ~ if_else(tolower(item) == tolower(descricao_restante), 
                              str_glue("{item} {marca}"), 

--- a/transformer/adapter/estados/Federal/contratos/adaptador_itens_compra_federal.R
+++ b/transformer/adapter/estados/Federal/contratos/adaptador_itens_compra_federal.R
@@ -77,7 +77,7 @@ adapta_info_itens_compras_federal <- function(itens_compra_federal_df, empenhos_
     dplyr::mutate(item = str_remove_all(item, "^'([[:alpha:]]*(.)*?)*'[[:blank:]]*")) %>%
     dplyr::mutate(ds_tidy = str_remove_all(descricao, "^( )*([$]|-|_|,|@|[.]|'|#|])*( )?")) %>%
     dplyr::mutate(ds_tidy = str_replace_all(ds_tidy, '((\r|\n|\t)|( ){2,})+', ' ')) %>% 
-    dplyr::mutate(ds_tidy = str_replace_all(ds_tidy, '^[0-9]*,[0-9]* (UNIDADE|GARRAFA|FRASCO|Unidade|Litro)', ' ')) %>% 
+    dplyr::mutate(ds_tidy = str_replace_all(ds_tidy, '^[0-9]*,[0-9]* ((?i)unidade|garrafa|frasco|litro)', ' ')) %>% 
     dplyr::mutate(ds_item = case_when(
       !is.na(item) ~ if_else(tolower(item) == tolower(descricao_restante), 
                              str_glue("{item} {marca}"), 

--- a/transformer/adapter/estados/Federal/contratos/adaptador_itens_compra_federal.R
+++ b/transformer/adapter/estados/Federal/contratos/adaptador_itens_compra_federal.R
@@ -75,7 +75,7 @@ adapta_info_itens_compras_federal <- function(itens_compra_federal_df, empenhos_
       vl_total_item_contrato = as.double(vl_total_item_contrato)
     ) %>%
     dplyr::mutate(item = str_remove_all(item, "^'([[:alpha:]]*(.)*?)*'[[:blank:]]*")) %>%
-    dplyr::mutate(ds_tidy = str_remove_all(descricao, '^[0-9]+,[0-9]+ [A-Za-záàâãéèêíïóôõöúçñÁÀÂÃÉÈÍÏÓÔÕÖÚÇÑ\'\.]* +([0-9]+,[0-9]+ [A-Za-záàâãéèêíïóôõöúçñÁÀÂÃÉÈÍÏÓÔÕÖÚÇÑ\'\.]* +)?')) %>% 
+    dplyr::mutate(ds_tidy = str_remove_all(descricao, '^[0-9]+,[0-9]+ [A-Za-záàâãéèêíïóôõöúçñÁÀÂÃÉÈÍÏÓÔÕÖÚÇÑ\'\\.]* +([0-9]+,[0-9]+ [A-Za-záàâãéèêíïóôõöúçñÁÀÂÃÉÈÍÏÓÔÕÖÚÇÑ\'\\.]* +)?')) %>% 
     dplyr::mutate(ds_tidy = str_remove_all(ds_tidy, "^( )*([$]|-|_|,|@|[.]|'|#|])*( )?")) %>%
     dplyr::mutate(ds_tidy = str_replace_all(ds_tidy, '((\r|\n|\t)|( ){2,})+', ' ')) %>% 
     dplyr::mutate(ds_item = case_when(

--- a/transformer/adapter/estados/Federal/contratos/adaptador_itens_compra_federal.R
+++ b/transformer/adapter/estados/Federal/contratos/adaptador_itens_compra_federal.R
@@ -77,6 +77,7 @@ adapta_info_itens_compras_federal <- function(itens_compra_federal_df, empenhos_
     dplyr::mutate(item = str_remove_all(item, "^'([[:alpha:]]*(.)*?)*'[[:blank:]]*")) %>%
     dplyr::mutate(ds_tidy = str_remove_all(descricao, "^( )*([$]|-|_|,|@|[.]|'|#|])*( )?")) %>%
     dplyr::mutate(ds_tidy = str_replace_all(ds_tidy, '((\r|\n|\t)|( ){2,})+', ' ')) %>% 
+    dplyr::mutate(ds_tidy = str_replace_all(ds_tidy, '^[0-9]*,[0-9]* (UNIDADE|GARRAFA|FRASCO|Unidade|Litro)', ' ')) %>% 
     dplyr::mutate(ds_item = case_when(
       !is.na(item) ~ if_else(tolower(item) == tolower(descricao_restante), 
                              str_glue("{item} {marca}"), 


### PR DESCRIPTION
Regras para descrição do item:

1. Remover unidades no inicio da string: ^[0-9]+,[0-9]+ [A-Za-záàâãéèêíïóôõöúçñÁÀÂÃÉÈÍÏÓÔÕÖÚÇÑ\'\.]* +([0-9]+,[0-9]+ [A-Za-záàâãéèêíïóôõöúçñÁÀÂÃÉÈÍÏÓÔÕÖÚÇÑ\'\.]* +)?

Para verificar no regex101: https://regex101.com/r/fVJds6/1/