### PR TITLE
917 script deleta empenhos rs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -120,3 +120,6 @@ feed-clean-empenho:
 feed-clean-empenho-federal:
 	docker-compose run --rm --no-deps feed python3.6 /feed/manage.py clean-empenho-federal
 .PHONY: feed-clean-empenho-federal
+delete-empenhos-rs:
+	docker-compose run --rm --no-deps feed python3.6 /feed/scripts/delete/delete_empenhos_rs.py
+.PHONY: delete-empenhos-rs

--- a/feed/manage.py
+++ b/feed/manage.py
@@ -76,12 +76,12 @@ def import_data():
 
 @click.command()
 def import_empenho_raw():
-    """Importa dados (licitações e contratos) para as tabelas do Banco de dados"""
+    """Importa dados (empenhos) para as tabelas do Banco de dados"""
     subprocess.run(['psql', '-h', host, '-U', user, '-d', db, '-f', '/feed/scripts/import/import_empenho_raw.sql'])
 
 @click.command()
 def import_empenho_raw_gov_federal():
-    """Importa dados (licitações e contratos) para as tabelas do Banco de dados"""
+    """Importa dados (empenhos) para as tabelas do Banco de dados"""
     subprocess.run(['psql', '-h', host, '-U', user, '-d', db, '-f', '/feed/scripts/import/import_empenhos_federais.sql'])
 
 @click.command()

--- a/feed/scripts/delete/delete_empenhos_rs.py
+++ b/feed/scripts/delete/delete_empenhos_rs.py
@@ -1,0 +1,8 @@
+import shutil
+
+try:
+    shutil.rmtree('/data/tce_rs/empenhos')
+except OSError as e:
+    print(e)
+else:
+    print("The directory is deleted successfully")

--- a/feed/scripts/delete/delete_empenhos_rs.py
+++ b/feed/scripts/delete/delete_empenhos_rs.py
@@ -1,8 +1,11 @@
-import shutil
+import os, shutil
 
-try:
-    shutil.rmtree('/data/tce_rs/empenhos')
-except OSError as e:
-    print(e)
-else:
-    print("The directory is deleted successfully")
+folder = '/data/tce_rs/empenhos'
+
+for the_file in os.listdir(folder):
+
+    try:
+        shutil.rmtree('/data/tce_rs/empenhos/' + the_file)
+    except Exception as e:
+        print(e)
+


### PR DESCRIPTION
Como testar:

Copie as pastas contidas em data/tce_rs/empenhos para outro local, dessa forma você não precisará baixa-las novamente após o teste

Execute make delete-empenhos-rs

Após o comando todas as pastas contidas em data/tce_rs/empenhos devem ter sido removidas